### PR TITLE
Home Manager and auto upgrade improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,15 +150,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1763748372,
-        "narHash": "sha256-AUc78Qv3sWir0hvbmfXoZ7Jzq9VVL97l+sP9Jgms+JU=",
-        "owner": "nix-community",
+        "lastModified": 1763807127,
+        "narHash": "sha256-0+gvAfUFuLXJ87yv8dXu4c6KTUxkWiJllQk+BrLWteU=",
+        "owner": "chrisnharvey",
         "repo": "home-manager",
-        "rev": "d10a9b16b2a3ee28433f3d1c603f4e9f1fecb8e1",
+        "rev": "a255dd17080bb73b85720919040989854435ef0c",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "chrisnharvey",
+        "ref": "user-service",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -26,18 +26,16 @@
     "dankMaterialShell": {
       "inputs": {
         "dgop": "dgop",
-        "dms-cli": "dms-cli",
         "nixpkgs": [
           "nixpkgs-unstable"
-        ],
-        "quickshell": "quickshell"
+        ]
       },
       "locked": {
-        "lastModified": 1760712688,
-        "narHash": "sha256-WAb3aAr3dhT8wgueanT6TaDB7S1w3akNPkmf0T4U5iQ=",
+        "lastModified": 1763810160,
+        "narHash": "sha256-mdmTeqtpkBzs+FchJQ4nw8pAUGIqkyIgOzIJgf9fUN4=",
         "owner": "chrisnharvey",
         "repo": "DankMaterialShell",
-        "rev": "16c1f867d1bd3dd732bbcc911df9536b53b883ba",
+        "rev": "86a1340a6d20a43f38792241ac2fbb195b3c0ed6",
         "type": "github"
       },
       "original": {
@@ -55,37 +53,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1760238269,
-        "narHash": "sha256-7CeGZM/Z/5Qt3AYByCRohGYGR1MRuXYzTTbkV/JxyAs=",
+        "lastModified": 1762435535,
+        "narHash": "sha256-QhzRn7pYN35IFpKjjxJAj3GPJECuC+VLhoGem3ezycc=",
         "owner": "AvengeMedia",
         "repo": "dgop",
-        "rev": "95acdfce2d323e28fa8f5a4f345160962034f2b5",
+        "rev": "6cf638dde818f9f8a2e26d0243179c43cb3458d7",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
         "repo": "dgop",
-        "type": "github"
-      }
-    },
-    "dms-cli": {
-      "inputs": {
-        "nixpkgs": [
-          "dankMaterialShell",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1760241259,
-        "narHash": "sha256-DlLGn+4M6tIafoDsHr2WhHG2hrHrC24S2IL3+KAvjEU=",
-        "owner": "AvengeMedia",
-        "repo": "danklinux",
-        "rev": "dae4c3ff4ce0feb930361c399747edb29d081775",
-        "type": "github"
-      },
-      "original": {
-        "owner": "AvengeMedia",
-        "repo": "danklinux",
         "type": "github"
       }
     },
@@ -345,27 +322,6 @@
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
-      }
-    },
-    "quickshell": {
-      "inputs": {
-        "nixpkgs": [
-          "dankMaterialShell",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1760228179,
-        "narHash": "sha256-4Z6k7lv3Zcgk3K+4h60LpqB9wCkR+utkYERU735U068=",
-        "ref": "refs/heads/master",
-        "rev": "c9d3ffb6043c5bf3f3009202bad7e0e5132c4a25",
-        "revCount": 693,
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
     home-manager.url = "github:nix-community/home-manager?ref=release-25.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager-unstable.url = "github:nix-community/home-manager";
+    home-manager-unstable.url = "github:chrisnharvey/home-manager?ref=user-service";
     home-manager-unstable.inputs.nixpkgs.follows = "nixpkgs-unstable";
 
     nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=v0.6.0";
@@ -96,6 +96,7 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.useUserService = true;
 
               home-manager.users.chris = import ./systems/dell-laptop/homes/chris/home.nix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.useUserService = true;
 
               home-manager.users.chris = import ./systems/steamdeck/homes/chris/home.nix;
 

--- a/systems/dell-laptop/configuration.nix
+++ b/systems/dell-laptop/configuration.nix
@@ -48,6 +48,8 @@
     dates = "20:00";
   };
 
+  systemd.services.nixos-upgrade.unitConfig.ConditionACPower = true;
+
   powerManagement.enable = true;
 
   # required for hibernation

--- a/systems/steamdeck/configuration.nix
+++ b/systems/steamdeck/configuration.nix
@@ -34,6 +34,7 @@
   };
 
   systemd.timers.nixos-upgrade.timerConfig.WakeSystem = true;
+  systemd.services.nixos-upgrade.unitConfig.ConditionACPower = true;
 
   programs.steam.enable = true;
   programs.steam.extest.enable = true;

--- a/systems/steamdeck/configuration.nix
+++ b/systems/steamdeck/configuration.nix
@@ -30,7 +30,8 @@
     enable = true;
     operation = "boot";
     flake = "github:chrisnharvey/nix-config";
-    dates = "04:00";
+    dates = "03:00";
+    allowReboot = true;
   };
 
   systemd.timers.nixos-upgrade.timerConfig.WakeSystem = true;


### PR DESCRIPTION
This pull request updates the NixOS configuration to improve system management and reliability for both the Dell laptop and Steam Deck setups. The main changes include switching to a custom fork of Home Manager for user service support, enabling user services, and adding safeguards for system upgrades to run only on AC power.

**Home Manager improvements:**

* Switched the `home-manager-unstable` input in `flake.nix` to use a custom fork (`chrisnharvey/home-manager?ref=user-service`), likely to support user service features.
* Enabled `home-manager.useUserService` for both the Dell laptop and Steam Deck, allowing Home Manager to manage user services. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R99) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R124)

**System upgrade reliability:**

* Added `ConditionACPower = true` to the `nixos-upgrade` systemd service for both devices, ensuring upgrades only run when connected to AC power. [[1]](diffhunk://#diff-270a95b7ffcfebd51981b0d2e7f0721bbd364ea0a6e61cdf78afdf5a8a0ce088R51-R52) [[2]](diffhunk://#diff-415e32a336544412027963a08f925ba2517ec08cbc91ab339e2d7e73cc74c25eL33-R38)
* For the Steam Deck, changed the scheduled upgrade time from 04:00 to 03:00, and enabled `allowReboot` to permit automatic reboots after upgrades.