### PR TITLE
Use Steam Deck OLED plymouth boot splash

### DIFF
--- a/systems/steamdeck/configuration.nix
+++ b/systems/steamdeck/configuration.nix
@@ -47,7 +47,18 @@
   jovian.decky-loader.user = "deck";
 
   boot.plymouth.enable = true;
-  boot.plymouth.theme = "bgrt";
+  boot.plymouth.theme = "steamos";
+  boot.plymouth.themePackages = [
+    (pkgs.steamdeck-hw-theme.overrideAttrs (oldAttrs: {
+      postFixup = (oldAttrs.postFixup or "") + ''
+        # Replace steamos.png with steamos-galileo.png
+        if [ -f $out/share/plymouth/themes/steamos/steamos-galileo.png ]; then
+          rm -f $out/share/plymouth/themes/steamos/steamos.png
+          cp $out/share/plymouth/themes/steamos/steamos-galileo.png $out/share/plymouth/themes/steamos/steamos.png
+        fi
+      '';
+    }))
+  ];
   boot.loader.timeout = 0;
   boot.initrd.systemd.enable = true;
   boot.initrd.verbose = false;


### PR DESCRIPTION
This pull request updates the Steam Deck's Plymouth boot splash configuration to use a custom theme and image. The main change is switching to the "steamos" theme and ensuring a specific image is used for the boot splash by overriding the theme package.

Plymouth theme customization:

* Changed the Plymouth boot splash theme from `"bgrt"` to `"steamos"` in `configuration.nix`.
* Added a custom override for the `steamdeck-hw-theme` package to replace the default `steamos.png` image with `steamos-galileo.png` during the build process, ensuring the desired boot image is displayed.