### PR TITLE
Add nix-index-database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,6 +200,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765267181,
+        "narHash": "sha256-d3NBA9zEtBu2JFMnTBqWj7Tmi7R5OikoU2ycrdhQEws=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "82befcf7dc77c909b0f2a09f5da910ec95c5b78f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixos-apple-silicon": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -316,6 +336,7 @@
         "jovian": "jovian",
         "nix-darwin": "nix-darwin",
         "nix-flatpak": "nix-flatpak",
+        "nix-index-database": "nix-index-database",
         "nixos-apple-silicon": "nixos-apple-silicon",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
 
     nixos-apple-silicon.url = "github:nix-community/nixos-apple-silicon";
     nixos-apple-silicon.inputs.nixpkgs.follows = "nixpkgs-unstable";
+
+    nix-index-database.url = "github:nix-community/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs-unstable";
   };
 
   # `outputs` are all the build result of the flake.
@@ -79,6 +82,7 @@
       dankMaterialShell,
       jovian,
       nixos-apple-silicon,
+      nix-index-database,
       ...
     }@inputs:
     {
@@ -146,6 +150,7 @@
         "macbook-nixos" = nixpkgs-unstable.lib.nixosSystem {
           system = "aarch64-linux";
           modules = [
+            nix-index-database.nixosModules.default
             nixos-apple-silicon.nixosModules.apple-silicon-support
             nix-flatpak.nixosModules.nix-flatpak
             dankMaterialShell.nixosModules.greeter
@@ -224,6 +229,7 @@
 
       darwinConfigurations."Chriss-MacBook-Pro" = nix-darwin.lib.darwinSystem {
         modules = [
+          nix-index-database.darwinModules.nix-index
           ./systems/macbook/configuration.nix
 
           home-manager-unstable.darwinModules.home-manager

--- a/systems/dell-laptop/homes/chris/home.nix
+++ b/systems/dell-laptop/homes/chris/home.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 {
   imports = [
+    inputs.nix-index-database.homeModules.default
     ../../../../homes/chris/backup.nix
     ../../../../homes/chris/common.nix
     # ../../homes/chris/gnome.nix

--- a/systems/macbook-nixos/homes/chris/home.nix
+++ b/systems/macbook-nixos/homes/chris/home.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 {
   imports = [
+    inputs.nix-index-database.homeModules.default
     ../../../../homes/chris/backup.nix
     ../../../../homes/chris/common.nix
     # ../../homes/chris/gnome.nix

--- a/systems/macbook/homes/chris/home.nix
+++ b/systems/macbook/homes/chris/home.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 {
   imports = [
+    inputs.nix-index-database.homeModules.default
     ../../../../homes/chris/common.nix
   ];
 

--- a/systems/rose-laptop/homes/chris/home.nix
+++ b/systems/rose-laptop/homes/chris/home.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 {
   imports = [
+    inputs.nix-index-database.homeModules.default
     ../../../../homes/chris/common.nix
   ];
 }

--- a/systems/steamdeck/homes/chris/home.nix
+++ b/systems/steamdeck/homes/chris/home.nix
@@ -2,10 +2,12 @@
   config,
   pkgs,
   lib,
+  inputs,
   ...
 }:
 {
   imports = [
+    inputs.nix-index-database.homeModules.default
     ../../../../homes/chris/backup.nix
     ../../../../homes/chris/common.nix
     # ../../homes/chris/gnome.nix


### PR DESCRIPTION
This pull request adds integration of the `nix-index-database` module across multiple NixOS and Darwin system configurations, as well as user home environments. This enables faster and more reliable package search capabilities using prebuilt package indexes.

**Integration of `nix-index-database`**

* Added `nix-index-database` as a flake input and ensured it follows the `nixpkgs-unstable` input for consistency. (`flake.nix`)
* Included `nix-index-database` in the list of flake inputs and made it available to system and home configurations. (`flake.nix`)

**System-level module integration**

* Enabled the `nix-index-database` NixOS module for the `macbook-nixos` system, and the Darwin module for the `Chriss-MacBook-Pro` configuration, ensuring system-wide availability of indexed package search. (`flake.nix`) [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R153) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R232)

**Home environment integration**

* Added the `nix-index-database` home module to user home configurations for `dell-laptop`, `macbook-nixos`, `macbook`, `rose-laptop`, and `steamdeck`, providing users with indexed package search in their environments. (`systems/dell-laptop/homes/chris/home.nix`, `systems/macbook-nixos/homes/chris/home.nix`, `systems/macbook/homes/chris/home.nix`, `systems/rose-laptop/homes/chris/home.nix`, `systems/steamdeck/homes/chris/home.nix`) [[1]](diffhunk://#diff-6a05555b54339cc31185ca73105febcd2c450b748d342f6a01a11c97704bd188L1-R9) [[2]](diffhunk://#diff-3e18066a822894eb48fbae172b4250310018ef586a918963fafdb180b8a87159L1-R9) [[3]](diffhunk://#diff-8494408b8801a5a91efb123ee1d1b5a55707a7b67926f6714caf2868e4c2ed4aL1-R9) [[4]](diffhunk://#diff-af7f9b294ad9b082fc2df69b59e68971e46822c48c4fb793d5aede8cc85c2dcfL1-R9) [[5]](diffhunk://#diff-a8e625006a14b49b3f9f94b29f5bd83af9efb2f1d11189bfe68874dcab1ba679R5-R10)